### PR TITLE
Bump to latest vipnode release

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,6 +1,6 @@
 ### Build stage
 FROM golang:alpine3.9 AS build-env
-ENV VERSION v2.0.1
+ENV VERSION v2.2.1
 # Install build deps
 RUN apk update && apk --no-cache add git gcc build-base
 # Get the source code


### PR DESCRIPTION
https://github.com/vipnode/vipnode/releases

Also I maintain a docker image here too, if you'd prefer to use that: https://cloud.docker.com/repository/docker/shazow/vipnode/tags (the `:release` tag is the latest stable release).